### PR TITLE
Updating the keys in the web docs after glvis-4.0

### DIFF
--- a/src/curvilinear-vtk-meshes.md
+++ b/src/curvilinear-vtk-meshes.md
@@ -33,13 +33,13 @@ SCALARS material int
 LOOKUP_TABLE default
 1
 ```
-Visualizing it with "`glvis -m quad.vtk`" and typing "`Aemiii`" in the GLVis window we get:
+Visualizing it with "`glvis -m quad.vtk`" and typing "`Aemooo`" in the GLVis window we get:
 
 ![](img/quad-vtk.png)
 
-The "`i`" key increases the reference element subdivision which gives an increasingly better approximation of the actual curvature of the element. To view the curvature of the mapping inside the element we can use the "I" key, e.g.,
+The "`o`" key increases the reference element subdivision which gives an increasingly better approximation of the actual curvature of the element. To view the curvature of the mapping inside the element we can use the "O" key, e.g.,
 ```sh
-glvis -m quad.vtk -k "AemIIiii"
+glvis -m quad.vtk -k "AemOOooo"
 ```
 ![](img/quad-vtk-2.png)
 
@@ -57,10 +57,10 @@ glvis -m square-disc-p2.vtk -k "Am"
 
 As well as [quadratic tetrahedral](https://github.com/mfem/mfem/blob/master/data/escher-p2.vtk) and [quadratic hexahedral](https://github.com/mfem/mfem/blob/master/data/fichera-q2.vtk) VTK meshes:
 ```sh
-glvis -m escher-p2.vtk -k "Aaaooooo**************"
+glvis -m escher-p2.vtk -k "Aaaaooooo**************"
 ```
 ![](img/escher-p2-vtk.png)
 ```sh
-glvis -m fichera-q2.vtk -k "Aaaooooo******"
+glvis -m fichera-q2.vtk -k "Aaaaooooo*****"
 ```
 ![](img/fichera-q2-vtk.png)

--- a/src/mesh-formats.md
+++ b/src/mesh-formats.md
@@ -173,7 +173,7 @@ Some possible [finite element collection](https://github.com/mfem/mfem/blob/mast
 
 For example, the [escher-p3.mesh](https://github.com/mfem/mfem/blob/master/data/escher-p3.mesh) from MFEM's [data directory](https://github.com/mfem/mfem/blob/master/data) describes a tetrahedral mesh with nodes given by a P3 vector Lagrangian finite element function. Visualizing this mesh with
 ```sh
-glvis -m escher-p3.mesh -k "Aaaoooooooooo**************tt"
+glvis -m escher-p3.mesh -k "Aaaaoooooooooo**************tt"
 ```
 we get:
 

--- a/src/nurbs.md
+++ b/src/nurbs.md
@@ -127,7 +127,7 @@ This above file, as well as other examples of NURBS meshes, can be found in [MFE
 ```sh
 glvis -m square-disc-nurbs.mesh
 ```
-which after several refinements with the "`i`" key looks like
+which after pressing "`e`", "`m`", "`A`", and several refinements with the "`o`" key looks like
 
 ![](img/glvis-square-disc-nurbs.png)
 

--- a/src/options-and-use.md
+++ b/src/options-and-use.md
@@ -203,8 +203,8 @@ glvis -saved glvis-saved.0001
 ```
 
 Below is the result for the above socket data using the following GLVis
-keystrokes in the OpenGL window: `AmttII` followed by multiple refinements with
-`i` and move/zoom adjustments with the mouse.
+keystrokes in the OpenGL window: `AmttOO` followed by multiple refinements with
+`o` and move/zoom adjustments with the mouse.
 
 ![](img/glvis-saved.png)
 
@@ -296,7 +296,7 @@ quadrilateral into the unit square:
 
 The above plot was produced with:
 ```sh
-glvis -m quad.vtk -g quad-vec.gf -k "fRjlAmeIIiiiiiiiiiiibbvuuuuuuuuuuu"
+glvis -m quad.vtk -g quad-vec.gf -k "RjlAmeOOooooooooooobbvuuuuuuuuuuu************"
 ```
 The transformation between the two domains can be further explored with the `b`
 and `n` keys.
@@ -369,7 +369,7 @@ solution quad.vtk quad-vec.gf
    view 0 0
    viewcenter 0 0
    zoom 1.95
-   keys fAmeIIiiiiiiiiiiibbvuuuuuuuuuuu
+   keys AmeOOooooooooooobbvuuuuuuuuuuu
 }
 
 # Take multiple screenshots. Executed after pressing the space bar.


### PR DESCRIPTION
Mostly replacing `i/I` in 2D with `o/O`