### PR TITLE
Website + Documentation updates for glvis-4.2

### DIFF
--- a/src/download.md
+++ b/src/download.md
@@ -1,13 +1,13 @@
 ## Latest Release
 
-[New features](https://github.com/glvis/glvis/blob/v4.1/CHANGELOG)
-┊ [User documentation](https://github.com/glvis/glvis/blob/v4.1/README)
+[New features](https://github.com/glvis/glvis/blob/v4.2/CHANGELOG)
+┊ [User documentation](https://github.com/glvis/glvis/blob/v4.2/README)
 ┊ [Code documentation](http://glvis.github.io/doxygen/html/index.html)
 ┊ [Sources](https://github.com/glvis/glvis)
 
 [<button type="button" class="btn btn-success">
-**Download glvis-4.1.tgz**
-</button>](https://bit.ly/glvis-4-1)
+**Download glvis-4.2.tgz**
+</button>](https://bit.ly/glvis-4-2)
 &nbsp;&nbsp;&nbsp;
 [<button type="button" class="btn btn-primary">
 **Use web version**
@@ -22,6 +22,7 @@ or [comments](https://github.com/glvis/glvis/issues/new?labels=comment).
 
  **Filename** | **Version** | **Release Date** | **Size** | **[SLOC](https://github.com/AlDanial/cloc)** | **Notes** |
  ------------ | ----------- | ---------------- | -------- | --------------------------------------- | --------- |
+  [glvis-4.2.tgz](https://bit.ly/glvis-4-2)   | v4.2 | Apr 2022 | X.XM | XXK  |  |
   [glvis-4.1.tgz](https://bit.ly/glvis-4-1)   | v4.1 | Aug 2021 | 2.4M | 34K  |  |
   [glvis-4.0.tgz](https://bit.ly/glvis-4-0)   | v4.0 | Dec 2020 | 1.3M | 33K  | _modern OpenGL, BSD license_ |
   [glvis-3.4.tgz](https://bit.ly/glvis-3-4)   | v3.4 | May 2018 | 199K | 27K |  |

--- a/src/download.md
+++ b/src/download.md
@@ -1,17 +1,26 @@
 ## Latest Release
 
 [New features](https://github.com/glvis/glvis/blob/v4.2/CHANGELOG)
-┊ [User documentation](https://github.com/glvis/glvis/blob/v4.2/README)
+┊ [User documentation](https://github.com/glvis/glvis/blob/v4.2/README.md)
 ┊ [Code documentation](http://glvis.github.io/doxygen/html/index.html)
 ┊ [Sources](https://github.com/glvis/glvis)
 
 [<button type="button" class="btn btn-success">
-**Download glvis-4.2.tgz**
+**<i class="fa fa-download"></i>&nbsp; glvis-4.2.tgz**
 </button>](https://bit.ly/glvis-4-2)
 &nbsp;&nbsp;&nbsp;
+[<button type="button" class="btn btn-success">
+**<i class="fa fa-apple"></i>&nbsp; Mac**
+</button>](https://bit.ly/glvis-mac)
+&nbsp;&nbsp;&nbsp;
+[<button type="button" class="btn btn-success">
+**<i class="fa fa-windows"></i>&nbsp; Windows**
+</button>](https://bit.ly/glvis-win)
+&nbsp;&nbsp;&nbsp;
 [<button type="button" class="btn btn-primary">
-**Use web version**
+**Web version**
 </button>](https://glvis.org/live)
+
 
 Please use the GitHub [issue tracker](https://github.com/glvis/glvis/issues)
 to report [bugs](https://github.com/glvis/glvis/issues/new?labels=bug)
@@ -22,7 +31,7 @@ or [comments](https://github.com/glvis/glvis/issues/new?labels=comment).
 
  **Filename** | **Version** | **Release Date** | **Size** | **[SLOC](https://github.com/AlDanial/cloc)** | **Notes** |
  ------------ | ----------- | ---------------- | -------- | --------------------------------------- | --------- |
-  [glvis-4.2.tgz](https://bit.ly/glvis-4-2)   | v4.2 | Apr 2022 | X.XM | XXK  |  |
+  [glvis-4.2.tgz](https://bit.ly/glvis-4-2)   | v4.2 | May 2022 | 2.4M | 37K  | _glTF export_ |
   [glvis-4.1.tgz](https://bit.ly/glvis-4-1)   | v4.1 | Aug 2021 | 2.4M | 34K  |  |
   [glvis-4.0.tgz](https://bit.ly/glvis-4-0)   | v4.0 | Dec 2020 | 1.3M | 33K  | _modern OpenGL, BSD license_ |
   [glvis-3.4.tgz](https://bit.ly/glvis-3-4)   | v3.4 | May 2018 | 199K | 27K |  |

--- a/src/features.md
+++ b/src/features.md
@@ -22,7 +22,7 @@ GLVis uses OpenGL with interactive refinement to accurately represent curved hig
 ## Lightweight and Convenient
 
 <img class="floatpad" src="../img/gallery/ball-nurbs-np16.png" width="240">
-GLVis has a fast [keystroke-based](https://raw.githubusercontent.com/glvis/glvis/master/README) interface and uses modern OpenGL that takes advantage of
+GLVis has a fast [keystroke-based](https://github.com/glvis/glvis/blob/master/README.md#key-commands) interface and uses modern OpenGL that takes advantage of
  hardware acceleration in modern GPUs.
 It has a number of convenient features, including:
 

--- a/src/gallery.md
+++ b/src/gallery.md
@@ -29,6 +29,12 @@ This page collects screenshots from various simulations that have used GLVis vis
 
 *One of the eight order (Q8) basis functions on the reference square. The sub-refinement in GLVis (key 'i') allows for the correct visualization of such high-order functions.*
 
+----
+
+![](img/gallery/sculpture-ar.jpg)
+
+*GLVis model opened in augmented reality with the [glTF model viewer](https://modelviewer.dev/editor).*
+
 </div><div class="col-md-5"  markdown="1">
 
 [![](img/gallery/triple-point_BLAST_q8q7.png)](img/gallery/triple-pt-np128.gif)
@@ -37,9 +43,9 @@ This page collects screenshots from various simulations that have used GLVis vis
 
 ----
 
-![](img/gallery/fem2d-2.png)
+[![](img/gallery/sculptures.jpg)](img/gallery/sculptures-full.jpg)
 
-*Level lines in 2D. Simulation with [MFEM](http://mfem.org).*
+*Raytraced glTF model in Blender which was exported from GLVis with the 'G' key. The mesh faces have been cut with 'Ctrl+F3'*
 
 ----
 
@@ -52,6 +58,12 @@ This page collects screenshots from various simulations that have used GLVis vis
 [![](img/gallery/partition-2048-a.png)](img/gallery/partition-2048-a.png)
 
 *Parallel partitioning of a non-conforming adaptively refined mesh between 2048 processors based on splitting a space-filling (Hilbert) curve.*
+
+----
+
+![](img/gallery/fem2d-2.png)
+
+*Level lines in 2D. Simulation with [MFEM](http://mfem.org).*
 
 </div><div class="col-md-3"  markdown="1">
 

--- a/src/index.md
+++ b/src/index.md
@@ -63,21 +63,21 @@ GLVis is based on the [MFEM](https://mfem.org) library and is used in the [BLAST
 
 Date         | Message
 ------------ | -----------------------------------------------------------------
-Aug 31, 2021 | Version 4.1 [released](https://github.com/glvis/glvis/blob/v4.1/CHANGELOG).
-Jul 10, 2021 | [MFEM Community Workshop](https://mfem.org/workshop)	 in October.
+Apr 21, 2022 | Version 4.2 [released](https://github.com/glvis/glvis/blob/v4.2/CHANGELOG).
+Jan 20, 2022 | New [FEM@LLNL seminar](seminar.md) series.
 Feb 19, 2021 | Web version at [glvis.org/live](https://glvis.org/live).
 Feb 17, 2021 | Jupyter support: [`pip install glvis`](https://github.com/GLVis/pyglvis).
 
 ## Latest Release
 
-[New features](https://github.com/glvis/glvis/blob/v4.1/CHANGELOG)
-┊ [User documentation](https://github.com/glvis/glvis/blob/v4.1/README)
+[New features](https://github.com/glvis/glvis/blob/v4.2/CHANGELOG)
+┊ [User documentation](https://github.com/glvis/glvis/blob/v4.2/README)
 ┊ [Code documentation](http://glvis.github.io/doxygen/html/index.html)
 ┊ [Sources](https://github.com/glvis/glvis)
 
 [<button type="button" class="btn btn-success">
-**Download glvis-4.1.tgz**
-</button>](https://bit.ly/glvis-4-1)
+**Download glvis-4.2.tgz**
+</button>](https://bit.ly/glvis-4-2)
 &nbsp;&nbsp;&nbsp;
 [<button type="button" class="btn btn-primary">
 **Use web version**

--- a/src/index.md
+++ b/src/index.md
@@ -18,7 +18,7 @@
       <div class="carousel-caption d-none" style="margin-top:-20px;">
         Accurate representation of many [finite elements](https://mfem.org/features/#higher-order-finite-element-spaces), support for [arbitrary high-order](mesh-formats.md#curvilinear-and-more-general-meshes) and [NURBS](nurbs.md) meshes
       </div>
-  </div>
+    </div>
     <div class="item">
       <img class="d-block w-100" src="img/slide3.png" usemap="#versionsmap">
       <map name="versionsmap">
@@ -28,6 +28,12 @@
       </map>
       <div class="carousel-caption d-none" style="margin-top:-15px;">
         Desktop, [Web](https://glvis.org/live) and [Jupyter](https://mybinder.org/v2/gh/GLVis/pyglvis/HEAD?filepath=examples) versions from the same code base
+      </div>
+    </div>
+    <div class="item">
+      [<img class="d-block w-100" src="img/slide4.jpg">](gallery.md)
+      <div class="carousel-caption d-none" style="margin-top:-20px;">
+        [glTF](https://www.khronos.org/gltf) export to [Blender](https://www.blender.org) and [augmented reality](https://modelviewer.dev/editor) tools
       </div>
     </div>
   </div>
@@ -63,7 +69,7 @@ GLVis is based on the [MFEM](https://mfem.org) library and is used in the [BLAST
 
 Date         | Message
 ------------ | -----------------------------------------------------------------
-Apr 21, 2022 | Version 4.2 [released](https://github.com/glvis/glvis/blob/v4.2/CHANGELOG).
+May 23, 2022 | Version 4.2 [released](https://github.com/glvis/glvis/blob/v4.2/CHANGELOG).
 Jan 20, 2022 | New [FEM@LLNL seminar](seminar.md) series.
 Feb 19, 2021 | Web version at [glvis.org/live](https://glvis.org/live).
 Feb 17, 2021 | Jupyter support: [`pip install glvis`](https://github.com/GLVis/pyglvis).
@@ -71,7 +77,7 @@ Feb 17, 2021 | Jupyter support: [`pip install glvis`](https://github.com/GLVis/p
 ## Latest Release
 
 [New features](https://github.com/glvis/glvis/blob/v4.2/CHANGELOG)
-┊ [User documentation](https://github.com/glvis/glvis/blob/v4.2/README)
+┊ [User documentation](https://github.com/glvis/glvis/blob/v4.2/README.md)
 ┊ [Code documentation](http://glvis.github.io/doxygen/html/index.html)
 ┊ [Sources](https://github.com/glvis/glvis)
 
@@ -83,6 +89,8 @@ Feb 17, 2021 | Jupyter support: [`pip install glvis`](https://github.com/GLVis/p
 **Use web version**
 </button>](https://glvis.org/live)
 
+[<i class="fa fa-apple"></i>](https://bit.ly/glvis-mac) [Mac](https://bit.ly/glvis-mac) ┊
+[<i class="fa fa-windows"></i>](https://bit.ly/glvis-win) [Windows](https://bit.ly/glvis-win) ┊
 [Older releases](download.md) ┊ [glvis.js](https://github.com/glvis/glvis-js) ┊ [pyglvis](https://github.com/glvis/pyglvis)
 
 ## Documentation

--- a/src/live/src/versions.js
+++ b/src/live/src/versions.js
@@ -1,5 +1,5 @@
 const versions = {
-  emscripten: "2.0.29",
-  mfem: "v4.3-470-g81493c10b",
-  glvis: "v4.1",
+  emscripten: "3.1.11",
+  mfem: "v4.4-775-g80033b00f",
+  glvis: "v4.2",
 };

--- a/src/news.md
+++ b/src/news.md
@@ -2,6 +2,8 @@
 
 &nbsp;       | |
 ------------ | -----------------------------------------------------------------
+Apr 21, 2022 | Version 4.2 [released](https://github.com/glvis/glvis/blob/v4.2/CHANGELOG).
+Jan 20, 2022 | [FEM@LLNL seminar series](seminar.md) starting.
 Aug 31, 2021 | Version 4.1 [released](https://github.com/glvis/glvis/blob/v4.1/CHANGELOG).
 Jul 10, 2021 | The inaugural [MFEM Community Workshop](workshop.md) will take place on October 20th, 2021.
 Feb 19, 2021 | Web version at [glvis.org/live](https://glvis.org/live).

--- a/src/news.md
+++ b/src/news.md
@@ -2,7 +2,7 @@
 
 &nbsp;       | |
 ------------ | -----------------------------------------------------------------
-Apr 21, 2022 | Version 4.2 [released](https://github.com/glvis/glvis/blob/v4.2/CHANGELOG).
+May 23, 2022 | Version 4.2 [released](https://github.com/glvis/glvis/blob/v4.2/CHANGELOG).
 Jan 20, 2022 | [FEM@LLNL seminar series](seminar.md) starting.
 Aug 31, 2021 | Version 4.1 [released](https://github.com/glvis/glvis/blob/v4.1/CHANGELOG).
 Jul 10, 2021 | The inaugural [MFEM Community Workshop](workshop.md) will take place on October 20th, 2021.

--- a/src/options-and-use.md
+++ b/src/options-and-use.md
@@ -77,7 +77,7 @@ All Options:
         Specify the port number on which to accept connections.
    -sec, --secure-sockets, -no-sec, --standard-sockets, current option: --standard-sockets
         Enable or disable GnuTLS secure sockets.
-   -mac, --save-stream, -no-mac, --dont-save-stream, current option: --dont-save-stream
+   -save, --save-stream, -no-save, --dont-save-stream, current option: --dont-save-stream
         In server mode, save incoming data to a file before visualization.
    -saved <string>, --saved-stream <string>, current value: (none)
         Load a GLVis stream saved to a file.
@@ -118,15 +118,21 @@ By default, the server is established on
 [port 19916](https://github.com/glvis/glvis/blob/master/glvis.cpp#L1137), but
 this can be changed with the `-p` option.
 
+<!--
 On legacy Mac machines with OS X Leopard, the server needs to be started with
 ```sh
-glvis -mac
+glvis -save
 ```
 This is due to the fact that Mac OS X returns an error when [fork() is called
 without an immediate exec()](http://developer.apple.com/library/mac/#technotes/tn2083/_index.html#//apple_ref/doc/uid/DTS10003794-CH1-SUBSUBSECTION66).
 *Note that this option is not necessary on newer versions of OS X.*
+-->
 
-A side effect of the `-mac` option is that all socket streams will be saved in
+To save the incoming data, the server needs to be started with
+```sh
+glvis -save
+```
+With the `-save` option, all socket streams will be saved in
 incrementally named files `glvis-saved.0001`, `glvis-saved.0002`, and so on.
 These socket files consist of a
 [data type identifier](https://github.com/glvis/glvis/blob/master/glvis.cpp#L111)

--- a/src/options-and-use.md
+++ b/src/options-and-use.md
@@ -10,8 +10,8 @@
   `glvis -np 4 -m mesh -g sol` (assuming data saved in files: `mesh.000000`,
   ... , `mesh.000003` and `sol.000000`, ...  , `sol.000003`)
   - Use `glvis -h` to get help on all command line options.
-  - See [README](https://raw.githubusercontent.com/glvis/glvis/master/README)
-  for a detail of the keystroke commands accepted in the GLVis interactive
+  - See [README.md](https://github.com/glvis/glvis/blob/master/README.md#key-commands)
+  for a detailed description of the keystroke commands accepted in the GLVis interactive
   window.
 
 Some of the command-line options of GLVis and its general use are described in


### PR DESCRIPTION
This will be the web PR to be merged as part of the glvis-4.2 release.

**Release date** 

~~April 21st, 2022 (Thursday)~~
May 23rd, 2022 (Monday)

**TODO**

- [x] Showcase glTF support?
- [x] Any additional fixes / improvements?
- [x] Merge https://github.com/GLVis/glvis/pull/227