### PR TITLE
Website changes for glvis-4.5

### DIFF
--- a/src/download.md
+++ b/src/download.md
@@ -30,7 +30,7 @@ or [comments](https://github.com/glvis/glvis/issues/new?labels=comment).
 
  **Filename** | **Version** | **Release Date** | **Size** | **[SLOC](https://github.com/AlDanial/cloc)** | **Notes** |
  ------------ | ----------- | ---------------- | -------- | --------------------------------------- | --------- |
-  [glvis-4.5.tgz](https://bit.ly/glvis-4-5)   | v4.5 | Feb 2026 | X.XM | XXK  |  |
+  [glvis-4.5.tgz](https://bit.ly/glvis-4-5)   | v4.5 | Feb 2026 | 2.6M | 44K  | _complex data visualization_ |
   [glvis-4.4.tgz](https://bit.ly/glvis-4-4)   | v4.4 | May 2025 | 2.6M | 41K  |  |
   [glvis-4.3.2.tgz](https://bit.ly/glvis-4-3-2)   | v4.3.2 | Sep 2024 | 2.4M | 40K  |  |
   [glvis-4.3.tgz](https://bit.ly/glvis-4-3)   | v4.3 | Aug 2024 | 2.4M | 39K  | _quadrature data visualization_ |

--- a/src/download.md
+++ b/src/download.md
@@ -1,12 +1,12 @@
 ## Latest Release
 
-[New features](https://github.com/glvis/glvis/blob/v4.4/CHANGELOG)
-┊ [User documentation](https://github.com/glvis/glvis/blob/v4.4/README.md)
+[New features](https://github.com/glvis/glvis/blob/v4.5/CHANGELOG)
+┊ [User documentation](https://github.com/glvis/glvis/blob/v4.5/README.md)
 ┊ [Sources](https://github.com/glvis/glvis)
 
 [<button type="button" class="btn btn-success">
-**<i class="fa fa-download"></i>&nbsp; glvis-4.4.tgz**
-</button>](https://bit.ly/glvis-4-4)
+**<i class="fa fa-download"></i>&nbsp; glvis-4.5.tgz**
+</button>](https://bit.ly/glvis-4-5)
 &nbsp;&nbsp;&nbsp;
 [<button type="button" class="btn btn-success">
 **<i class="fa fa-apple"></i>&nbsp; Mac**
@@ -30,6 +30,7 @@ or [comments](https://github.com/glvis/glvis/issues/new?labels=comment).
 
  **Filename** | **Version** | **Release Date** | **Size** | **[SLOC](https://github.com/AlDanial/cloc)** | **Notes** |
  ------------ | ----------- | ---------------- | -------- | --------------------------------------- | --------- |
+  [glvis-4.5.tgz](https://bit.ly/glvis-4-5)   | v4.5 | Jan 2026 | X.XM | XXK  |  |
   [glvis-4.4.tgz](https://bit.ly/glvis-4-4)   | v4.4 | May 2025 | 2.6M | 41K  |  |
   [glvis-4.3.2.tgz](https://bit.ly/glvis-4-3-2)   | v4.3.2 | Sep 2024 | 2.4M | 40K  |  |
   [glvis-4.3.tgz](https://bit.ly/glvis-4-3)   | v4.3 | Aug 2024 | 2.4M | 39K  | _quadrature data visualization_ |

--- a/src/download.md
+++ b/src/download.md
@@ -30,7 +30,7 @@ or [comments](https://github.com/glvis/glvis/issues/new?labels=comment).
 
  **Filename** | **Version** | **Release Date** | **Size** | **[SLOC](https://github.com/AlDanial/cloc)** | **Notes** |
  ------------ | ----------- | ---------------- | -------- | --------------------------------------- | --------- |
-  [glvis-4.5.tgz](https://bit.ly/glvis-4-5)   | v4.5 | Jan 2026 | X.XM | XXK  |  |
+  [glvis-4.5.tgz](https://bit.ly/glvis-4-5)   | v4.5 | Feb 2026 | X.XM | XXK  |  |
   [glvis-4.4.tgz](https://bit.ly/glvis-4-4)   | v4.4 | May 2025 | 2.6M | 41K  |  |
   [glvis-4.3.2.tgz](https://bit.ly/glvis-4-3-2)   | v4.3.2 | Sep 2024 | 2.4M | 40K  |  |
   [glvis-4.3.tgz](https://bit.ly/glvis-4-3)   | v4.3 | Aug 2024 | 2.4M | 39K  | _quadrature data visualization_ |

--- a/src/index.md
+++ b/src/index.md
@@ -69,20 +69,20 @@ GLVis is based on the [MFEM](https://mfem.org) library and is used in the [BLAST
 
 Date         | Message
 ------------ | -----------------------------------------------------------------
-May 1, 2025 | Version 4.4 [released](https://github.com/glvis/glvis/blob/v4.4/CHANGELOG).
+Jan XX, 2026 | Version 4.5 [released](https://github.com/glvis/glvis/blob/v4.5/CHANGELOG).
 Jan 20, 2022 | New [FEM@LLNL seminar](https://mfem.org/seminar/) series.
 Feb 19, 2021 | Web version at [glvis.org/live](https://glvis.org/live).
 Feb 17, 2021 | Jupyter support: [`pip install glvis`](https://github.com/GLVis/pyglvis).
 
 ## Latest Release
 
-[New features](https://github.com/glvis/glvis/blob/v4.4/CHANGELOG)
-┊ [User documentation](https://github.com/glvis/glvis/blob/v4.4/README.md)
+[New features](https://github.com/glvis/glvis/blob/v4.5/CHANGELOG)
+┊ [User documentation](https://github.com/glvis/glvis/blob/v4.5/README.md)
 ┊ [Sources](https://github.com/glvis/glvis)
 
 [<button type="button" class="btn btn-success">
-**Download glvis-4.4.tgz**
-</button>](https://bit.ly/glvis-4-4)
+**Download glvis-4.5.tgz**
+</button>](https://bit.ly/glvis-4-5)
 &nbsp;&nbsp;&nbsp;
 [<button type="button" class="btn btn-primary">
 **Use web version**

--- a/src/index.md
+++ b/src/index.md
@@ -69,7 +69,7 @@ GLVis is based on the [MFEM](https://mfem.org) library and is used in the [BLAST
 
 Date         | Message
 ------------ | -----------------------------------------------------------------
-Jan XX, 2026 | Version 4.5 [released](https://github.com/glvis/glvis/blob/v4.5/CHANGELOG).
+Feb 6, 2026  | Version 4.5 [released](https://github.com/glvis/glvis/blob/v4.5/CHANGELOG).
 Jan 20, 2022 | New [FEM@LLNL seminar](https://mfem.org/seminar/) series.
 Feb 19, 2021 | Web version at [glvis.org/live](https://glvis.org/live).
 Feb 17, 2021 | Jupyter support: [`pip install glvis`](https://github.com/GLVis/pyglvis).

--- a/src/mesh-formats.md
+++ b/src/mesh-formats.md
@@ -169,7 +169,7 @@ Ordering: 0
 <z-coordinate degrees of freedom>
 ...
 ```
-Some possible [finite element collection](https://github.com/mfem/mfem/blob/master/fem/fe_coll.hpp) choices are: `Linear`, `Quadratic` and `Cubic` corresponding to curvilinear P1/Q1, P2/Q2 and P3/Q3 meshes. The algorithm for the numbering of the degrees of freedom can be found in [MFEM's source code](https://github.com/mfem/mfem/blob/v4.8/fem/fespace.cpp#L2746).
+Some possible [finite element collection](https://github.com/mfem/mfem/blob/master/fem/fe_coll.hpp) choices are: `Linear`, `Quadratic` and `Cubic` corresponding to curvilinear P1/Q1, P2/Q2 and P3/Q3 meshes. The algorithm for the numbering of the degrees of freedom can be found in [MFEM's source code](https://github.com/mfem/mfem/blob/v4.9/fem/fespace.cpp#L2733).
 
 For example, the [escher-p3.mesh](https://github.com/mfem/mfem/blob/master/data/escher-p3.mesh) from MFEM's [data directory](https://github.com/mfem/mfem/blob/master/data) describes a tetrahedral mesh with nodes given by a P3 vector Lagrangian finite element function. Visualizing this mesh with
 ```sh

--- a/src/news.md
+++ b/src/news.md
@@ -2,10 +2,10 @@
 
 &nbsp;       | |
 ------------ | -----------------------------------------------------------------
-Jan XX, 2026 | Version 4.5 [released](https://github.com/glvis/glvis/blob/v4.5/CHANGELOG).
-May 1, 2025 | Version 4.4 [released](https://github.com/glvis/glvis/blob/v4.4/CHANGELOG).
+Feb 6, 2026  | Version 4.5 [released](https://github.com/glvis/glvis/blob/v4.5/CHANGELOG).
+May 1, 2025  | Version 4.4 [released](https://github.com/glvis/glvis/blob/v4.4/CHANGELOG).
 Sep 27, 2024 | Version 4.3.2 [released](https://github.com/glvis/glvis/blob/v4.3.2/CHANGELOG).
-Aug 7, 2024 | Version 4.3 [released](https://github.com/glvis/glvis/blob/v4.3/CHANGELOG).
+Aug 7, 2024  | Version 4.3 [released](https://github.com/glvis/glvis/blob/v4.3/CHANGELOG).
 May 23, 2022 | Version 4.2 [released](https://github.com/glvis/glvis/blob/v4.2/CHANGELOG).
 Jan 20, 2022 | [FEM@LLNL seminar series](https://mfem.org/seminar/) starting.
 Aug 31, 2021 | Version 4.1 [released](https://github.com/glvis/glvis/blob/v4.1/CHANGELOG).

--- a/src/news.md
+++ b/src/news.md
@@ -2,6 +2,7 @@
 
 &nbsp;       | |
 ------------ | -----------------------------------------------------------------
+Jan XX, 2026 | Version 4.5 [released](https://github.com/glvis/glvis/blob/v4.5/CHANGELOG).
 May 1, 2025 | Version 4.4 [released](https://github.com/glvis/glvis/blob/v4.4/CHANGELOG).
 Sep 27, 2024 | Version 4.3.2 [released](https://github.com/glvis/glvis/blob/v4.3.2/CHANGELOG).
 Aug 7, 2024 | Version 4.3 [released](https://github.com/glvis/glvis/blob/v4.3/CHANGELOG).

--- a/src/options-and-use.md
+++ b/src/options-and-use.md
@@ -83,10 +83,12 @@ All Options:
         Number of digits used for processor ranks in file names.
    -run <string>, --run-script <string>, current value: (none)
         Run a GLVis script file.
-   -k <string>, --keys <string>, current value: (none)
-        Execute key shortcut commands in the GLVis window.
    -pal <string>, --palettes <string>, current value: (none)
         Palette file.
+   -pname <string>, --palette-name <string>, current value: (none)
+        Palette name.
+   -k <string>, --keys <string>, current value: (none)
+        Execute key shortcut commands in the GLVis window.
    -fo, --fix-orientations, -no-fo, --dont-fix-orientations, current option: --dont-fix-orientations
         Attempt to fix the orientations of inverted elements.
    -a, --real-attributes, -ap, --processor-attributes, current option: --processor-attributes
@@ -97,6 +99,8 @@ All Options:
         Save the mesh coloring generated when opening only a mesh.
    -p <int>, --listen-port <int>, current value: 19916
         Specify the port number on which to accept connections.
+   -pr, --persistent, -no-pr, --no-persistent, current option: --persistent
+        Keep server running after all windows are closed.
    -sec, --secure-sockets, -no-sec, --standard-sockets, current option: --standard-sockets
         Enable or disable GnuTLS secure sockets.
    -save, --save-stream, -no-save, --dont-save-stream, current option: --dont-save-stream
@@ -109,6 +113,8 @@ All Options:
         Set the window height.
    -wt <string>, --window-title <string>, current value: (default)
         Set the window title.
+   -hl, --headless, -no-hl, --no-headless, current option: --no-headless
+        Start headless (no GUI) visualization.
    -c <string>, --plot-caption <string>, current value: (none)
         Set the plot caption (visible when colorbar is visible).
    -fn <string>, --font <string>, current value: (default)
@@ -117,7 +123,7 @@ All Options:
         Set the multisampling mode (toggled with the 'A' key).
    -lw <double>, --line-width <double>, current value: 1
         Set the line width (multisampling off).
-   -mslw <double>, --multisample-line-width <double>, current value: 1
+   -mslw <double>, --multisample-line-width <double>, current value: 1.4
         Set the line width (multisampling on).
    -oldgl, --legacy-gl, -anygl, --any-gl, current option: --any-gl
         Only try to create a legacy OpenGL (< 2.1) context.
@@ -276,6 +282,8 @@ window_geometry <x> <y> <w> <h> - Set the position and size of the window.
 window_title '<title>' - Set title of the window.
 keys <keys> - Send the control key sequence.
 palette <index> - Set the palette index.
+palette_name <palette_name> - Use palette with given name.
+palette_file <filename> - Load in a palette file.
 palette_repeat <times> - Set the repetition of the palette.
 camera <cam[0]> ... <cam[2]> <dir[0]> ... <dir[2]> <up[0]> ... <up[2]> - Set the camera position, direction and upward vector.
 plot_caption '<caption>' - Set the plot caption.
@@ -653,6 +661,8 @@ colorbar_numberformat '<format>' - Set the colorbar number format.
 window <x> <y> <w> <h> - Set the position and size of the window.
 keys <keys> - Send the control key sequence.
 palette <index> - Set the palette index.
+palette_file <filename> - Load in a palette file.
+palette_name <palette_name> - Use palette with given name.
 palette_repeat <times> - Set the repetition of the palette.
 toggle_attributes <1/0> [[<1/0>] ...]; - Toggle visibility of the attributes.
 rotmat <[0,0]> <[1,0]> ... <[3,3]> - Set the rotation matrix.
@@ -660,4 +670,5 @@ camera <cam[0]> ... <cam[2]> <dir[0]> ... <dir[2]> <up[0]> ... <up[2]> - Set the
 scale <scale> - Set the scaling factor.
 translate <x> <y> <z> - Set the translation coordinates.
 plot_caption '<caption>' - Set the plot caption.
+headless  - Change the session to headless.
 ```

--- a/src/options-and-use.md
+++ b/src/options-and-use.md
@@ -145,7 +145,7 @@ application without any options:
 glvis
 ```
 By default, the server is established on
-[port 19916](https://github.com/glvis/glvis/blob/v4.4/glvis.cpp#L1421), but
+[port 19916](https://github.com/glvis/glvis/blob/v4.5/glvis.cpp#L386), but
 this can be changed with the `-p` option.
 
 <!--

--- a/src/parallel-visualization.md
+++ b/src/parallel-visualization.md
@@ -12,14 +12,14 @@ For data saved in separate files, e.g. `mesh.000000`, ... , `mesh.000003` and `s
 ```sh
 glvis -np 4 -m mesh -g sol
 ```
-In other words, the actual mesh and solution file names are obtained from the above prefixes "`mesh`" and "`sol`" by appending "`.`" followed by a 6-digit processor/subdomain number padded with 0's, see e.g. [this example](https://github.com/mfem/mfem/blob/v4.8/examples/ex1p.cpp#L286). (Note that the related obsolete option -par3d was removed in version 2.0).
+In other words, the actual mesh and solution file names are obtained from the above prefixes "`mesh`" and "`sol`" by appending "`.`" followed by a 6-digit processor/subdomain number padded with 0's, see e.g. [this example](https://github.com/mfem/mfem/blob/v4.9/examples/ex1p.cpp#L286). (Note that the related obsolete option -par3d was removed in version 2.0).
 
 For results send by separate socket connections from each processor, the
 parallel format just adds a prefix specifying the total number of processors and the current processor id:
 ```sh
 parallel <num_proc> <myid>
 ```
-An example of this can be found [here](https://github.com/mfem/mfem/blob/v4.8/examples/ex1p.cpp#L305).
+An example of this can be found [here](https://github.com/mfem/mfem/blob/v4.9/examples/ex1p.cpp#L305).
 
 To illustrate the parallel visualization capabilities of GLVis, suppose that we have solves a simple Poisson problem on a 2x2 square grid using 2 processors. The processor mesh files generated, e.g. by [MFEM's Parallel Example 1](https://github.com/mfem/mfem/blob/master/examples/ex1p.cpp), are "`mesh.000000`":
 ```sh


### PR DESCRIPTION
🔗 Companion PR for the **glvis-4.5** release in https://github.com/GLVis/glvis/pull/351

🔴 **TODO:**

🏁 **Endgame:**

🟢 **DONE:**
- [x] Update the Mac binary with signed+notarized image
- [x] Update the size and SLOC for this version in `download.md`
- [x] Update code references to v4.5 (updating the code lines as well!)
- [x] Add new command line options
- [x] Update command and stream options
- [x] Update version number in `index.md`, `download.md` and `news.md`
- [x] Create bit.ly shortlink (https://bit.ly/glvis-4-5)
